### PR TITLE
updated for ROOT with C++11/14

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -29,9 +29,10 @@ if os.getenv('ROOTSYS') == None:
 env = Environment(CPPPATH=["/opt/local/include","include",".","src/root","src/reader","src/tools"])
 env.Append(ENV = os.environ)
 env.Append(CPPPATH=["src/root","src/evio"])
-env.Append(CCFLAGS=["-O2","-fPIC","-m64","-fmessage-length=0","-g"])
+env.Append(CFLAGS=["-O2","-fPIC","-m64","-fmessage-length=0","-g"])
+env.Append(CXXFLAGS=["-O2","-fPIC","-m64","-fmessage-length=0","-g"])
 #env.Append(CCFLAGS=["-O2","-fPIC","-m32","-fmessage-length=0"])
-env.Append(LIBPATH=["/opt/local/lib","/usr/lib","lib"])
+#env.Append(LIBPATH=["/opt/local/lib","/usr/lib","lib"])
 #env.Append(LIBS=["iG5io"])
 #-----------------------------------------------------------------------
 #  Parsing input Arguments
@@ -44,15 +45,18 @@ if ARGUMENTS.get('verbose') != '1':
 #   env['CCCOMSTR']   = "--> Compiling : $TARGET"
    env['LINKCOMSTR'] = "[==] --> Linking : $TARGET"
 #   env['ARCOMSTR']   = "[==] --> Archiving : $TARGET"
-   env.Append(CCFLAGS=["-w"])
+   env.Append(CXXFLAGS=["-w"])
+   env.Append(CFLAGS=["-w"])
 
 if int(compileMode):
    print '-->  Compiling library in debug mode...'
-   env.Append(CCFLAGS=['-g'])
+   env.Append(CXXFLAGS=['-g'])
+   env.Append(CFLAGS=['-g'])
 
 if os.getenv('OSTYPE') != None:
    if os.getenv('OSTYPE')=='darwin':
-      env.Append(CCFLAGS=['-DDarwin'])
+      env.Append(CXXFLAGS=['-DDarwin'])
+      env.Append(CFLAGS=['-DDarwin'])
 #------------------------------------------------------------------------
 # Check Essential setup of enviromental variables (GOOLIB and HDF5_DIR) -
 #------------------------------------------------------------------------

--- a/loadROOTLibrary.py
+++ b/loadROOTLibrary.py
@@ -7,8 +7,8 @@ import os
 def  initROOTLibrary(env):
     OSENV   = os.environ
     ROOTSYS = OSENV['ROOTSYS']
-    env.Append(CPPPATH=ROOTSYS+'/include')
-    env.Append(CPPPATH=ROOTSYS+'/include/root')
+    env.Append(CXXPATH=ROOTSYS+'/include')
+    env.Append(CXXPATH=ROOTSYS+'/include/root')
     rootlibs = []
     root_config_libs = os.popen('$ROOTSYS/bin/root-config --glibs').readline()[:-1].split()
 
@@ -17,6 +17,9 @@ def  initROOTLibrary(env):
             rootlibs += [item[2:]]
 
     rootlibs.append('EG')
-    env.Append(LIBPATH=[ROOTSYS+'/lib'])
-    env.Append(LIBPATH=[ROOTSYS+'/lib/root'])
+    env.Append(LIBPATH=os.popen('$ROOTSYS/bin/root-config --libdir').readline()[:-1])
     env.Append(LIBS=rootlibs)
+
+
+    rootflags = os.popen('$ROOTSYS/bin/root-config --cflags').readline()[:-1].split() 
+    env.Append(CXXFLAGS=rootflags)


### PR DESCRIPTION
NOTE: these changes were tested on an updated macOS Sierra, as well as ifarm1401 (common environment version 2.0)

CHANGES:
* updated loadROOTLibrary.py to automatically use the CFLAGS used by ROOT, this ensures the C++11/14 compiler flags are set if necessary.

* changed incorrectly used CPPFLAGS (c preprocessor flags) to CXXFLAGS (C++ flags)

* changed CCFLAGS (not used by the C compiler) into CFLAGS and CXXFLAGS (resp. C and C++ flags).